### PR TITLE
fix bug where empty search crashes app

### DIFF
--- a/app/src/main/java/ch/beerpro/presentation/profile/mybeers/MyBeersFragment.java
+++ b/app/src/main/java/ch/beerpro/presentation/profile/mybeers/MyBeersFragment.java
@@ -55,11 +55,13 @@ public class MyBeersFragment extends Fragment {
     }
 
     private void handleBeersChanged(List<MyBeer> beers) {
-        adapter.submitList(new ArrayList<>(beers));
-        if (beers.isEmpty()) {
+        if (beers == null || beers.isEmpty()) {
+            adapter.submitList(new ArrayList<>());
             emptyView.setVisibility(View.VISIBLE);
             recyclerView.setVisibility(View.GONE);
-        } else {
+        }
+        else {
+            adapter.submitList(new ArrayList<>(beers));
             emptyView.setVisibility(View.GONE);
             recyclerView.setVisibility(View.VISIBLE);
         }


### PR DESCRIPTION
When the beer search list is empty and we try to close the search (top right X) the app crashes.
This aims to fix this.