### PR TITLE
fix: restraint comment textview to not overflow over screen

### DIFF
--- a/app/src/main/res/layout/activity_details_ratings_listentry.xml
+++ b/app/src/main/res/layout/activity_details_ratings_listentry.xml
@@ -8,12 +8,13 @@
 
         <TextView
             android:id="@+id/comment"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="16dp"
             android:layout_marginTop="8dp"
             android:layout_marginEnd="16dp"
             android:text="Comment"
+            app:layout_constrainedWidth="true"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/photo" />

--- a/app/src/main/res/layout/fragment_ratings_listentry.xml
+++ b/app/src/main/res/layout/fragment_ratings_listentry.xml
@@ -36,12 +36,13 @@
 
         <TextView
             android:id="@+id/comment"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="16dp"
             android:layout_marginTop="8dp"
             android:layout_marginEnd="16dp"
             android:text="Comment"
+            app:layout_constrainedWidth="true"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/beerName" />


### PR DESCRIPTION
Previously if long comments were added to ratings they would overflow the screen. The now added constraints prevent this behaviour.